### PR TITLE
Add children prop type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,8 @@ export interface ReactNativeSideMenuProps {
      * Page overlay color when sidebar open
      * @default transparent
      */
-    overlayColor?: string
+    overlayColor?: string;
+    children?: ReactNode;
 }
 
 export default class SideMenu extends Component<ReactNativeSideMenuProps> {


### PR DESCRIPTION
Thanks for creating the library!

Currently I get the following TS errors.

```
 Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<SideMenu> & Readonly<ReactNativeSideMenuProps>'.
```

To solve this, I added children prop type.
